### PR TITLE
修改启动代码，启动时指定-y可以跳过所有确认

### DIFF
--- a/NodeQuality.sh
+++ b/NodeQuality.sh
@@ -239,7 +239,15 @@ function main(){
 
     start_ascii
 
-    ask_question
+    if [[ "$1" == "-y" ]]; then
+        _yellow_bold "'-y' flag detected. Skipping questions and using defaults."
+        run_yabs_test='y'
+        run_ip_quality_test='y'
+        run_net_quality_test='y'
+        run_net_trace_test='y'
+    else
+        ask_question
+    fi
 
     _green_bold 'Clean Up before Installation'
     pre_init
@@ -280,4 +288,4 @@ function main(){
     post_cleanup
 }
 
-main
+main "$@"


### PR DESCRIPTION
在 `ask_question` 前进行参数判断，如果传递了 `-y` 参数，则跳过确认（全yes），如果未传递参数，则正常执行逐步确认。

这样做就可以直接 `bash <(curl -sL https://run.NodeQuality.com) -y` 来执行了，比较爽。